### PR TITLE
Update `BitmapTileLayer.widgetId` to be a string

### DIFF
--- a/lonboard/_layer.py
+++ b/lonboard/_layer.py
@@ -591,12 +591,12 @@ class BitmapTileLayer(BaseLayer):
     balanced among the endpoints, based on the tile index.
     """
 
-    widget_id = t.Int(None, allow_none=True).tag(sync=True)
+    widget_id = t.Unicode(None, allow_none=True).tag(sync=True)
     """
     The id of the dashboard widget that this tile layer belongs to. If set, MUST match the
     widget.id field sent down in the dashboard JSON.
 
-    - Type: `int`, optional
+    - Type: `str`, optional
     - Default: `None`
     """
 

--- a/lonboard/types/layer.py
+++ b/lonboard/types/layer.py
@@ -98,7 +98,7 @@ class BitmapLayerKwargs(BaseLayerKwargs, total=False):
 
 class BitmapTileLayerKwargs(BaseLayerKwargs, total=False):
     data: str | Sequence[str]
-    widget_id: int | None
+    widget_id: str | None
     tile_size: int
     zoom_offset: int
     max_zoom: int

--- a/src/model/layer.ts
+++ b/src/model/layer.ts
@@ -181,7 +181,7 @@ export class BitmapModel extends BaseLayerModel {
 export class BitmapTileModel extends BaseLayerModel {
   static layerType = "bitmap-tile";
 
-  protected widgetId: number | null = null;
+  protected widgetId: string | null = null;
   protected data!: TileLayerProps["data"];
   protected tileSize: TileLayerProps["tileSize"];
   protected zoomOffset: TileLayerProps["zoomOffset"];


### PR DESCRIPTION
Closes #17
Is a revision of #20, which added wigetId as an int, here we are updating it to be a string because plots require us to have the widget ID as `string` even though maps can handle an `int`, and we want to have the same code on web treat both types of widgets.